### PR TITLE
Readonly dumping updates

### DIFF
--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -793,7 +793,7 @@ def dump(principal_db, readonly_db=None, delete_existing=False,
               help="If given, the lambda function serving the REST API will not"
                    "be modified to redirect from the readonly database to the"
                    "principal database while readonly is being loaded.")
-@click.option('--debug-log', default=False, is_flag=True,
+@click.option('--debug-log', is_flag=True,
               help="If set, the logging level will be set to DEBUG.")
 def run_all(
     continuing,

--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -793,8 +793,16 @@ def dump(principal_db, readonly_db=None, delete_existing=False,
               help="If given, the lambda function serving the REST API will not"
                    "be modified to redirect from the readonly database to the"
                    "principal database while readonly is being loaded.")
-def run_all(continuing, delete_existing, load_only, dump_only,
-            no_redirect_to_principal):
+@click.option('--debug-log', default=False, is_flag=True,
+              help="If set, the logging level will be set to DEBUG.")
+def run_all(
+    continuing,
+    delete_existing,
+    load_only,
+    dump_only,
+    no_redirect_to_principal,
+    debug_log
+):
     """Generate new dumps and list existing dumps."""
     from indra_db import get_ro
 
@@ -804,10 +812,21 @@ def run_all(continuing, delete_existing, load_only, dump_only,
     else:
         ro_manager = None
 
-    dump(get_db('primary', protected=False),
-         ro_manager, delete_existing,
-         continuing, load_only, dump_only,
-         no_redirect_to_principal=no_redirect_to_principal)
+    # Set the debug level.
+    if debug_log:
+        from indra.belief import logger as indra_belief_logger
+        logger.setLevel(logging.DEBUG)
+        indra_belief_logger.setLevel(logging.DEBUG)
+
+    dump(
+        principal_db=get_db('primary', protected=False),
+        readonly_db=ro_manager,
+        delete_existing=delete_existing,
+        allow_continue=continuing,
+        load_only=load_only,
+        dump_only=dump_only,
+        no_redirect_to_principal=no_redirect_to_principal
+    )
 
 
 @dump_cli.command()

--- a/indra_db/cli/dump.py
+++ b/indra_db/cli/dump.py
@@ -685,6 +685,7 @@ def dump(principal_db, readonly_db=None, delete_existing=False,
         # START THE DUMP
         if delete_existing and 'readonly' in principal_db.get_schemas():
             principal_db.drop_schema('readonly')
+            logger.info("Deleted existing readonly schema.")
 
         start = Start()
         start.dump(continuing=allow_continue)

--- a/indra_db/cli/reading.py
+++ b/indra_db/cli/reading.py
@@ -218,7 +218,7 @@ class BulkAwsReadingManager(BulkReadingManager):
         'sparser': 5000,
         'isi': 5000,
         'trips': 500,
-        'eidos': 5000,
+        'eidos': 1000,  # 5000 id jobs were often terminated by BidEvictionEvent
         'mti': None,  # meaning all content run in a single job.
     }
 

--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -1543,7 +1543,11 @@ class ReadonlyDatabaseManager(DatabaseManager):
         be missing. This function rebuilds missing indices while skipping
         any existing ones.
         """
-        from psycopg2 import UndefinedTable
+        try:
+            from psycopg2 import UndefinedTable
+        except ImportError:
+            from psycopg2.errors import UndefinedTable
+
         for key, table in self.tables.items():
             try:
                 table.build_indices(self)

--- a/indra_db_service/cli/__init__.py
+++ b/indra_db_service/cli/__init__.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import click
 

--- a/indra_db_service/cli/__init__.py
+++ b/indra_db_service/cli/__init__.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import click
 

--- a/indra_db_service/test_api.py
+++ b/indra_db_service/test_api.py
@@ -615,14 +615,16 @@ class TestDbApi(unittest.TestCase):
         assert 'invalid credentials' in reason.lower()
         assert 'api key' in reason.lower()
 
-    def test_get_all_curations_wrong_auth(self):
-        if TEST_DEPLOYMENT:
-            raise SkipTest("Cannot test particular auth with single API key.")
-        resp = self.app.get('curation/list?api_key=OTHER_API_KEY')
-        assert resp.status_code == 403
-        reason = resp.json['reason']
-        assert 'insufficient permissions' in reason.lower()
-        assert 'get all curations' in reason.lower()
+    # def test_get_all_curations_wrong_auth(self):
+    #     # NOTE: The endpoint has been changed and 403 can no longer be
+    #     # returned by it. This test is kept for reference.
+    #     if TEST_DEPLOYMENT:
+    #         raise SkipTest("Cannot test particular auth with single API key.")
+    #     resp = self.app.get('curation/list?api_key=OTHER_API_KEY')
+    #     assert resp.status_code == 403
+    #     reason = resp.json['reason']
+    #     assert 'insufficient permissions' in reason.lower()
+    #     assert 'get all curations' in reason.lower()
 
     def test_interaction_query(self):
         self.__time_query('get', 'metadata/relations/from_agents',


### PR DESCRIPTION
_(old description from Aug 10, 2023)_

This PR adds updates associated with the latest readonly deployment and one commit that is part of the latest indra_db docker from last year.

-----
**2025 update:**

This PR is now mostly superseded by work on the new readonly pipeline. However, the changes were used in a previous dump that used the old pipeline that ran with this branch, and there are two commits that are worth keeping: one is commenting out a test that is deprecated and the other one reduces the number of IDs used per eidos reading job this.

Together this makes this PR still relevant for merging.