### PR TITLE
Update Flask-JWT-Extended, Flask

### DIFF
--- a/indra_db_service/api.py
+++ b/indra_db_service/api.py
@@ -371,6 +371,7 @@ def get_statements(result_type, method):
 
 
 @app.route("/expand", methods=["POST"])
+@jwt_nontest_optional
 def expand_meta_row():
     start_time = datetime.now()
 

--- a/indra_db_service/cli/__init__.py
+++ b/indra_db_service/cli/__init__.py
@@ -10,15 +10,22 @@ def main():
 
 @main.command()
 @click.argument('deployment', nargs=1)
-def push(deployment):
+@click.option('-s', '--settings', 'zappa_settings_file',
+              default='zappa_settings.json',
+              help="Specify the zappa settings file to use. Default is "
+                   "'zappa_settings.json'.")
+def push(deployment, zappa_settings_file):
     """Push a new deployment to the remote lambdas using zappa."""
-    from indra_db_service.cli.zappa_tools import fix_permissions, ZAPPA_CONFIG
+    import json
+    from pathlib import Path
+    from indra_db_service.cli.zappa_tools import fix_permissions
     click.echo(f"Updating {deployment} deployment.")
-    if ZAPPA_CONFIG not in os.listdir('.'):
-        click.echo(f"Please run in directory with {ZAPPA_CONFIG}.")
+    if not Path(zappa_settings_file).exists():
+        click.echo(f"Zappa settings file not found: {zappa_settings_file}")
         return
+    zappa_settings = json.load(open(zappa_settings_file, 'r'))
     os.system(f'zappa update {deployment}')
-    fix_permissions(deployment)
+    fix_permissions(deployment, zappa_settings=zappa_settings)
 
 
 @main.command()

--- a/indra_db_service/cli/__main__.py
+++ b/indra_db_service/cli/__main__.py
@@ -1,0 +1,5 @@
+from . import main
+
+
+if __name__ == '__main__':
+    main()

--- a/indra_db_service/cli/zappa_tools.py
+++ b/indra_db_service/cli/zappa_tools.py
@@ -1,5 +1,3 @@
-import os
-import json
 import boto3
 
 from indra_db.config import CONFIG
@@ -10,20 +8,8 @@ from indra_db.util.aws import get_role_kwargs
 aws_role = CONFIG['lambda']['role']
 aws_primary_function = 'indra-db-api-ROOT'
 
-# Load the Zappa config file.
-ZAPPA_CONFIG = 'zappa_settings.json'
 
-
-def load_zappa_settings() -> dict:
-    if not os.path.exists(ZAPPA_CONFIG):
-        raise Exception(f"No valid zappa config file present. "
-                        f"Expecting: {ZAPPA_CONFIG}")
-    with open('zappa_settings.json', 'r') as f:
-        zappa_settings = json.load(f)
-    return zappa_settings
-
-
-def fix_permissions(deployment) -> None:
+def fix_permissions(deployment, zappa_settings) -> None:
     """Add permissions to the lambda function to allow access from API Gateway.
 
     When Zappa runs, it removes permission for the primary endpoint to call
@@ -31,7 +17,6 @@ def fix_permissions(deployment) -> None:
     permissions, and is intended to be run after a zappa update.
     """
     # Get relevant settings from the zappa config.
-    zappa_settings = load_zappa_settings()
     project_name = zappa_settings[deployment]['project_name']
     region = zappa_settings[deployment]['aws_region']
     if zappa_settings[deployment]['profile_name'].lower() != aws_role.lower():

--- a/indra_db_service/config.py
+++ b/indra_db_service/config.py
@@ -12,7 +12,7 @@ __all__ = [
 
 from os import environ
 from pathlib import Path
-from flask_jwt_extended import jwt_optional
+from flask_jwt_extended import jwt_required
 
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get("INDRA_DB_API_DEPLOYMENT")
@@ -39,4 +39,4 @@ def jwt_nontest_optional(func):
     if TESTING["status"]:
         return func
     else:
-        return jwt_optional(func)
+        return jwt_required(optional=True)(func)


### PR DESCRIPTION
This PR along with updates in [`indra`](https://github.com/gyorilab/indra_cogex/pull/172) and [`ui_util`](https://github.com/gyorilab/ui_util/pull/20) updates the usage of flask_jwt_extended decorator to be compatible with flask_jwt_extended>3, which is a requirement for using Flask>=3.

See sorgerlab/indra#1448.