### PR TITLE
Make sql str executable style

### DIFF
--- a/indra_db/databases.py
+++ b/indra_db/databases.py
@@ -19,7 +19,7 @@ from sqlalchemy.schema import DropTable
 from sqlalchemy.sql.expression import Delete, Update
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import declarative_base, DeclarativeMeta
-from sqlalchemy import create_engine, inspect, UniqueConstraint, func
+from sqlalchemy import create_engine, inspect, UniqueConstraint, func, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.engine.url import make_url
@@ -253,7 +253,7 @@ class DatabaseManager(object):
                     self.url,
                     connect_args={'connect_timeout': 1}
             ).connect() as connection:
-                connection.execute('SELECT 1 AS ping;')
+                connection.execute(text('SELECT 1 AS ping;'))
         except Exception as err:
             logger.warning(f"Database {repr(self.url)} is not available: {err}")
             self.available = False


### PR DESCRIPTION
A follow-up commit to fix the "sqlalchemy>2.0" modifies. Made the SQL str executable in the connection engine.