### PR TITLE
Fix form submit URL

### DIFF
--- a/indra_db_service/templates/search_statements.html
+++ b/indra_db_service/templates/search_statements.html
@@ -31,7 +31,7 @@
         queryString += 'format=html';
 
         // Build URL
-        let baseUrl = '{{ endpoint }}statements/from_agents?';
+        let baseUrl = `${window.location.href}/from_agents?`;
 
         let getUrl = baseUrl + queryString;
 


### PR DESCRIPTION
This PR updates the form submission functionality so that JavaScript is used to get the current URL instead of what is passed from the backend in the `endpoint` parameter.