### PR TITLE
PMC_OA, Docker and Elsevier Update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,54 @@
+ARG AWS_ACCOUNT_ID
+FROM ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/indra:latest
+
+ARG BUILD_BRANCH
+ARG INDRA_BRANCH
+
+ENV DIRPATH /sw
+ENV PYTHONPATH "$PYTHONPATH:${DIRPATH}/covid-19"
+WORKDIR $DIRPATH
+
+RUN cd indra && \
+    git fetch --all && \
+    git checkout $INDRA_BRANCH && \
+    echo "INDRA_BRANCH=" $INDRA_BRANCH && \
+    pip install -e . -U
+
+# Install libpq5 and some other necessities.
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y lsb-release && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    apt-get install -y libpq5 libpq-dev postgresql-client-13 postgresql-client-common && \
+    pip install awscli
+
+# Install psycopg2
+RUN git clone https://github.com/psycopg/psycopg2.git && \
+    cd psycopg2 && \
+    python setup.py build && \
+    python setup.py install
+
+# Install pgcopy
+RUN git clone https://github.com/pagreene/pgcopy.git && \
+    cd pgcopy && \
+    python setup.py install
+
+# Install covid-19
+RUN git clone https://github.com/indralab/covid-19.git
+
+# Install sqlalchemy < 1.4 (due to indirect dependencies, it may be a later
+# version in the indra:db image)
+RUN pip install "sqlalchemy<1.4"
+
+# Install indra_db
+RUN git clone https://github.com/indralab/indra_db.git && \
+    cd indra_db && \
+    pip install -e .[all] && \
+    pip list && \
+    echo "PYTHONPATH =" $PYTHONPATH && \
+    git checkout $BUILD_BRANCH && \
+    echo "BUILD_BRANCH =" $BUILD_BRANCH && \
+    git branch && \
+    echo "[indra]" > /root/.config/indra/config.ini
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,9 @@ RUN git clone https://github.com/indralab/covid-19.git
 # version in the indra:db image)
 RUN pip install "sqlalchemy<1.4"
 
+#install bs4
+RUN pip install bs4
+
 # Install indra_db
 RUN git clone https://github.com/indralab/indra_db.git && \
     cd indra_db && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN pip install "sqlalchemy<1.4"
 RUN pip install bs4
 
 # Install indra_db
-RUN git clone --branch pmc_oa https://github.com/haohangyan/indra_db.git && \
+RUN git clone https://github.com/gyorilab/indra_db.git && \
     cd indra_db && \
     pip install -e .[all] && \
     pip list && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN pip install "sqlalchemy<1.4"
 RUN pip install bs4
 
 # Install indra_db
-RUN git clone https://github.com/indralab/indra_db.git && \
+RUN git clone --branch pmc_oa https://github.com/haohangyan/indra_db.git && \
     cd indra_db && \
     pip install -e .[all] && \
     pip list && \

--- a/docker/buildspec.yml
+++ b/docker/buildspec.yml
@@ -1,0 +1,18 @@
+version: 0.1
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build --build-arg BUILD_BRANCH=$BUILD_BRANCH --build-arg INDRA_BRANCH=$INDRA_BRANCH --build-arg AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID -t $IMAGE_REPO_NAME:$IMAGE_TAG -f docker/Dockerfile .
+      - docker tag $IMAGE_REPO_NAME:$IMAGE_TAG $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+      - docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME:$IMAGE_TAG

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1852,14 +1852,7 @@ class Elsevier(ContentManager):
                 pmid_set = pickle.load(f)
                 print(f"Loaded {len(pmid_set)} PMIDs from {pmid_set_file}")
             pmid_iter = iter(pmid_set)
-            while True:
-                batch = set(islice(pmid_iter, 1000))
-                if not batch:
-                    break
-                article_tuples = self.get_content_from_pmids(batch)
 
-                self.copy_into_db(db, 'text_content', article_tuples,
-                                  self.tc_cols)
         else:
             if not (os.path.exists(edge_file) and os.path.exists(node_file)):
                 logger.error("Missing edge/node file from indra cogex.")
@@ -1877,14 +1870,15 @@ class Elsevier(ContentManager):
 
             print(f"Saved {len(pmid_results)} PMIDs to {pmid_set_file}")
             pmid_iter = iter(pmid_results)
-            while True:
-                batch = set(islice(pmid_iter, 1000))
-                if not batch:
-                    break
-                article_tuples = self.get_content_from_pmids(batch)
 
-                self.copy_into_db(db, 'text_content', article_tuples,
-                                  self.tc_cols)
+        while True:
+            batch = set(islice(pmid_iter, 1000))
+            if not batch:
+                break
+            article_tuples = self.get_content_from_pmids(batch)
+
+            self.copy_into_db(db, 'text_content', article_tuples,
+                              self.tc_cols)
 
 
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1915,7 +1915,7 @@ class Elsevier(ContentManager):
 
         total = len(pmid_list)
         batch_size = 100
-        with tqdm(total=total, desc="Processing PMIDs", unit="batch") as pbar:
+        with tqdm(total=total, desc="Processing PMIDs", unit="paper") as pbar:
             for i in range(0, total, batch_size):
                 batch = pmid_list[i:i + batch_size]
                 article_tuples = self.get_content_from_pmids(batch,

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1980,6 +1980,20 @@ def run(task, sources, continuing, debug):
             ContentManager().update(db)
 
 
+@content.command()
+@click.option("--edge-file", type=click.Path(exists=True), required=False,
+              help="Path to the INDRA Cogex edge file.")
+@click.option("--node-file", type=click.Path(exists=True), required=False,
+              help="Path to the INDRA Cogex node file.")
+def update_elsevier(edge_file, node_file):
+    """Run Elsevier update_by_cogex from the command line."""
+    from indra_db.util import get_db
+    db = get_db('primary')
+    manager = Elsevier()
+    manager.update_by_cogex(db=db, edge_file=edge_file, node_file=node_file)
+
+
+
 @content.command('list')
 @click.option('-l', '--long', is_flag=True,
               help="Include a list of the most recently added content for all "

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1681,7 +1681,7 @@ class Elsevier(ContentManager):
         logger.debug("Found %d elsevier text refs." % len(elsevier_trs))
         article_tuples = self.__get_content(elsevier_trs)
         logger.debug("Got %d elsevier results." % len(article_tuples))
-         self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
+        self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
         return
 
     def _get_elsevier_content(self, db, tr_query, continuing=False):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1398,8 +1398,8 @@ class PmcOA(PmcManager):
                     "the last update.")
         archive_set = {
             f['archive'] for f in self.file_data
-            if 'Last Updated (YYYY-MM-DD HH:MM:SS)' in f and
-            datetime.strptime(f['Last Updated (YYYY-MM-DD HH:MM:SS)'],
+            if 'LastUpdated (YYYY-MM-DD HH:MM:SS)' in f and
+            datetime.strptime(f['LastUpdated (YYYY-MM-DD HH:MM:SS)'],
                               '%Y-%m-%d %H:%M:%S') > min_date
         }
         return archive_set

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1681,9 +1681,8 @@ class Elsevier(ContentManager):
         logger.debug("Found %d elsevier text refs." % len(elsevier_trs))
         article_tuples = self.__get_content(elsevier_trs)
         logger.debug("Got %d elsevier results." % len(article_tuples))
+         self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
         return
-        # self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
-        # return
 
     def _get_elsevier_content(self, db, tr_query, continuing=False):
         """Get the elsevier content given a text ref query object."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1365,11 +1365,18 @@ class PmcOA(PmcManager):
         return self.licenses[pmcid]
 
     def is_archive(self, k):
-        return k.endswith('.xml.tar.gz')
+        return k.endswith('.tar.gz')
 
     def get_all_archives(self):
-        return [path.join('oa_bulk', k) for k in self.ftp.ftp_ls('oa_bulk')
-                if self.is_archive(k)]
+        """Get a list of PMC OA .tar.gz archives in the known subfolders."""
+        archives = []
+        for subf in ['oa_comm', 'oa_noncomm', 'oa_other']:
+            subpath = self.ftp._path_join('oa_bulk', subf, 'xml')
+            all_files = self.ftp.ftp_ls(subpath)
+            for f in all_files:
+                if self.is_archive(f):
+                    archives.append(self.ftp._path_join(subpath, f))
+        return archives
 
     def get_file_data(self):
         """Retrieve the metadata provided by the FTP server for files."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1875,9 +1875,11 @@ class Elsevier(ContentManager):
             random.shuffle(pmid_list)
             with open(pmid_list_file, "wb") as f:
                 pickle.dump(pmid_list, f)
+            with open(pmid_tr_dict, "wb") as f:
+                pickle.dump(pmid_id_dict, f)
 
             logger.info(f"Saved {len(pmid_list)} PMIDs to {pmid_list_file}")
-        return
+
         total = len(pmid_list)
         batch_size = 100
         with tqdm(total=total, desc="Processing PMIDs", unit="batch") as pbar:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1861,7 +1861,7 @@ class Elsevier(ContentManager):
                 self.copy_into_db(db, 'text_content', article_tuples,
                                   self.tc_cols)
         else:
-            if not edge_file or node_file:
+            if not (os.path.exists(edge_file) and os.path.exists(node_file)):
                 logger.error("Missing edge/node file from indra cogex.")
             elsevier_nlm_ids = self.get_elsevier_nlm_ids(node_file, self.__journal_set)
             print("Total Elsevier Journals", len(elsevier_nlm_ids))

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -425,7 +425,7 @@ class ContentManager(object):
                 id_updates = {}
                 for i, id_type in enumerate(self.tr_cols):
                     if id_type not in match_id_types:
-                        continue                    
+                        continue
                     # Check if the text ref is missing that id.
                     if getattr(tr, id_type) is None:
                         # If so, and if our new data does have that id, update
@@ -1413,7 +1413,7 @@ class PmcOA(PmcManager):
         # Upload these archives.
         logger.info(f"Updating the database with "
                     f"{len(archives)} changed archives.")
-        self.upload_archives(db, archives, batch_size=5000)
+        self.upload_archives(db, archives, pmcid_set=load_pmcid_set)
         return True
 
     def find_all_missing_pmcids(self, db):
@@ -1666,8 +1666,9 @@ class Elsevier(ContentManager):
         logger.debug("Found %d elsevier text refs." % len(elsevier_trs))
         article_tuples = self.__get_content(elsevier_trs)
         logger.debug("Got %d elsevier results." % len(article_tuples))
-        self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
         return
+        # self.copy_into_db(db, 'text_content', article_tuples, self.tc_cols)
+        # return
 
     def _get_elsevier_content(self, db, tr_query, continuing=False):
         """Get the elsevier content given a text ref query object."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1859,8 +1859,11 @@ class Elsevier(ContentManager):
 
         existing_text_ref_ids = set(
             row[0] for row in db.session.query(db.TextContent.text_ref_id)
-            .filter(db.TextContent.text_ref_id.in_(text_ref_ids),
-                    db.TextContent.source == "elsevier")
+            .filter(
+                db.TextContent.text_ref_id.in_(text_ref_ids),
+                db.TextContent.source == "elsevier",
+                db.TextContent.text_type == "fulltext"
+            )
             .all()
         )
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1984,11 +1984,17 @@ def run(task, sources, continuing, debug):
 
 @content.command()
 @click.option("--edge-file", type=click.Path(exists=True), required=False,
-              help="Path to the INDRA Cogex edge file.")
+              help="Path to the INDRA CoGEx PubMed Journal edge file.")
 @click.option("--node-file", type=click.Path(exists=True), required=False,
-              help="Path to the INDRA Cogex node file.")
+              help="Path to the INDRA CoGEx PubMed Journal node file.")
 def update_elsevier(edge_file, node_file):
-    """Run Elsevier update_by_cogex from the command line."""
+    """Run Elsevier update_by_cogex from the command line.
+
+    The goal is to find articles that are Elsevier-published
+    based on the journal's NLM ID and the curated list of relevant
+    Elsevier journals. The node and edge files are typically
+    inside the cogex data folder under the pubmed/journal path.
+    """
     from indra_db.util import get_db
     db = get_db('primary')
     manager = Elsevier()

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1581,7 +1581,7 @@ class Manuscripts(PmcManager):
 
 class Elsevier(ContentManager):
     """Content manager for maintaining content from Elsevier."""
-    my_source = 'elsevier'
+    my_source = 'elsevier bv'
     tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
                'content',)
 
@@ -1622,6 +1622,8 @@ class Elsevier(ContentManager):
             meta_data_dict = None
             while num_retries < max_retries:
                 try:
+                    if not pmid_set:
+                        logger.info("Empty pmid_id set")
                     meta_data_dict = get_metadata_for_ids(pmid_set)
                     break
                 except Exception as e:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1715,6 +1715,13 @@ class Elsevier(ContentManager):
                              'matched': self.__matched_journal_set}, f)
         return True
 
+    def copy_into_db(self, db, table_name, data, columns):
+        """Write data to the given table using COPY"""
+        logger.info(f"Copying {len(data)} rows into {table_name}.")
+        if not data:
+            return
+        db.copy_report_lazy(table_name, data, columns)
+
     @ContentManager._record_for_review
     def populate(self, db, n_procs=1, continuing=False):
         """Load all available elsevier content for refs with no pmc content."""

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1581,7 +1581,7 @@ class Manuscripts(PmcManager):
 
 class Elsevier(ContentManager):
     """Content manager for maintaining content from Elsevier."""
-    my_source = 'elsevier bv'
+    my_source = 'elsevier'
     tc_cols = ('text_ref_id', 'source', 'format', 'text_type',
                'content',)
 
@@ -1611,7 +1611,7 @@ class Elsevier(ContentManager):
             if tr.doi is not None:
                 publisher = get_publisher(tr.doi)
                 if publisher is not None and\
-                   publisher.lower() == self.my_source:
+                   publisher.lower() == "elsevier bv":
                     tr_set.remove(tr)
                     elsevier_tr_set.add(tr)
 

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1408,12 +1408,14 @@ class PmcOA(PmcManager):
     @DGContext.wrap(gatherer, my_source)
     def update(self, db):
         load_pmcid_set = self.find_all_missing_pmcids(db)
-        archives = self.get_archives_for_pmcids(load_pmcid_set)
+        archives_dict = self.get_archives_for_pmcids(load_pmcid_set)
 
         # Upload these archives.
-        logger.info(f"Updating the database with "
-                    f"{len(archives)} changed archives.")
-        self.upload_archives(db, archives, pmcid_set=load_pmcid_set)
+        logger.info("Beginning to upload archives.")
+        for archive, pmcid_set in sorted(archives_dict.items()):
+            logging.info(f"Extracting {len(pmcid_set)} articles from "
+                         f"{archive}.")
+            self.upload_archives(db, [archive], pmcid_set=pmcid_set)
         return True
 
     def find_all_missing_pmcids(self, db):

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -1778,7 +1778,7 @@ class Elsevier(ContentManager):
     def get_elsevier_nlm_ids(self, node_file, journal_set):
         """Extract NLM IDs of Elsevier journals from node.tsv.gz."""
         elsevier_nlm_ids = set()
-        print("iterating node.tsv.gz")
+        logger.info("iterating node.tsv.gz")
         with gzip.open(node_file, "rt", encoding="utf-8") as f:
             next(f)  # Skip header
             for line in f:
@@ -1836,7 +1836,7 @@ class Elsevier(ContentManager):
                 # content_zip = zip_string(content_str)
                 # article_tuples.add((pmid, self.my_source, formats.TEXT,
                 #                     text_type, content_zip))
-        print(f"Retrieved {len(article_tuples)} articles with "
+        logger.info(f"Retrieved {len(article_tuples)} articles with "
               f"{fulltext_count} fulltext and {abstract_count} abstract.")
         return article_tuples
 
@@ -1850,25 +1850,25 @@ class Elsevier(ContentManager):
         if os.path.exists(pmid_set_file):
             with open(pmid_set_file, "rb") as f:
                 pmid_set = pickle.load(f)
-                print(f"Loaded {len(pmid_set)} PMIDs from {pmid_set_file}")
+                logger.info(f"Loaded {len(pmid_set)} PMIDs from {pmid_set_file}")
             pmid_iter = iter(pmid_set)
 
         else:
             if not (os.path.exists(edge_file) and os.path.exists(node_file)):
                 logger.error("Missing edge/node file from indra cogex.")
             elsevier_nlm_ids = self.get_elsevier_nlm_ids(node_file, self.__journal_set)
-            print("Total Elsevier Journals", len(elsevier_nlm_ids))
+            logger.info("Total Elsevier Journals", len(elsevier_nlm_ids))
 
             elsevier_pmids = self.get_elsevier_pmids(edge_file, elsevier_nlm_ids)
-            print(f"Total Elsevier PMIDs: {len(elsevier_pmids)}")
+            logger.info(f"Total Elsevier PMIDs: {len(elsevier_pmids)}")
 
             all_pmid = self.get_pmids_without_fulltext(db)
-            print("Number of pmid that don't have fulltext", len(all_pmid))
+            logger.info("Number of pmid that don't have fulltext", len(all_pmid))
             pmid_results = all_pmid & elsevier_pmids
             with open(pmid_set_file, "wb") as f:
                 pickle.dump(pmid_results, f)
 
-            print(f"Saved {len(pmid_results)} PMIDs to {pmid_set_file}")
+            logger.info(f"Saved {len(pmid_results)} PMIDs to {pmid_set_file}")
             pmid_iter = iter(pmid_results)
 
         while True:

--- a/indra_db/cli/content.py
+++ b/indra_db/cli/content.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta
 from os import path, remove, rename, listdir
 from typing import Tuple
 
+from indra.literature.elsevier_client import has_full_text
 from indra.util import zip_string, batch_iter
 from indra.util import UnicodeXMLTreeBuilder as UTB
 
@@ -1659,9 +1660,13 @@ class Elsevier(ContentManager):
             if id_dict:
                 content_str = download_article_from_ids(**id_dict)
                 if content_str is not None:
+                    if has_full_text(content_str):
+                        text_type = texttypes.FULLTEXT
+                    else:
+                        text_type = texttypes.ABSTRACT
                     content_zip = zip_string(content_str)
                     article_tuples.add((tr.id, self.my_source, formats.TEXT,
-                                        texttypes.FULLTEXT, content_zip))
+                                        text_type, content_zip))
         return article_tuples
 
     def __process_batch(self, db, tr_batch):

--- a/indra_db/cli/elsevier_titles.txt
+++ b/indra_db/cli/elsevier_titles.txt
@@ -1,0 +1,960 @@
+Acta Biomaterialia
+Acta Genetica Sinica
+Acta Haematologica Polonica
+Acta Histochemica
+Acta Pharmaceutica Sinica B
+Acta Tropica
+Actualités Pharmaceutiques
+Actualités Pharmaceutiques Hospitalières
+Acute Pain
+Advanced Drug Delivery Reviews
+Advances in Biological Regulation
+Advances in Biophysics
+Advances in Enzyme Regulation
+Advances in Free Radical Biology & Medicine
+Advances in Integrative Medicine
+Advances in Medical Sciences
+Advances in Neuroimmunology
+Advances in Radiation Oncology
+Ageing Research Reviews
+Agri Gene
+Agricultural Wastes
+Alcohol
+Alcoholism and Drug Addiction
+Alergologia Polska - Polish Journal of Allergology
+Algal Research
+Allergologia et Immunopathologia
+The American Journal of Geriatric Pharmacotherapy
+The American Journal of Human Genetics
+American Journal of Infection Control
+The American Journal of Pathology
+American Pharmacy
+Anaerobe
+Analytica Chimica Acta
+Analytical Biochemistry
+Animal Reproduction Science
+Annales de Cardiologie et d'Angéiologie
+Annales d'Endocrinologie
+Annales de Génétique
+Annales de l'Institut Pasteur / Actualités
+Annales de l'Institut Pasteur / Immunologie
+Annales de l'Institut Pasteur / Microbiologie
+Annales de l'Institut Pasteur / Virologie
+Annales Pharmaceutiques Françaises
+Annals of Agrarian Science
+Annals of Anatomy - Anatomischer Anzeiger
+Antimicrobic Newsletter
+Antimicrobics and Infectious Diseases Newsletter
+Antiviral Research
+Applied & Translational Genomics
+Aquaculture and Fisheries
+Archiv für Protistenkunde
+Archives of Biochemistry and Biophysics
+Archives of Cardiovascular Diseases
+Archives of Gerontology and Geriatrics
+Artery Research
+Arthropod Structure & Development
+Asian Journal of Pharmaceutical Sciences
+Asian Journal of Urology
+Asian Pacific Journal of Tropical Biomedicine
+Atherosclerosis
+Autoimmunity Reviews
+Avances en Diabetología
+Baillière's Clinical Endocrinology and Metabolism
+Baillière's Clinical Haematology
+BBA Clinical
+Beiträge zur Pathologie
+Beni-Suef University Journal of Basic and Applied Sciences
+Best Practice & Research Clinical Endocrinology & Metabolism
+Best Practice & Research Clinical Gastroenterology
+Best Practice & Research Clinical Haematology
+Bioactive Carbohydrates and Dietary Fibre
+Biocatalysis and Agricultural Biotechnology
+Biochemical and Biophysical Research Communications
+Biochemical Education
+Biochemical Engineering Journal
+Biochemical Medicine
+Biochemical Medicine and Metabolic Biology
+Biochemical and Molecular Medicine
+Biochemical Pharmacology
+Biochemical Systematics and Ecology
+Biochemie und Physiologie der Pflanzen
+Biochemistry and Biophysics Reports
+Biochemistry and Molecular Biology Education
+Biochimica et Biophysica Acta
+Biochimica et Biophysica Acta (BBA) - Bioenergetics
+Biochimica et Biophysica Acta (BBA) - Biomembranes
+Biochimica et Biophysica Acta (BBA) - Biophysics including Photosynthesis
+Biochimica et Biophysica Acta (BBA) - Enzymology
+Biochimica et Biophysica Acta (BBA) - Enzymology and Biological Oxidation
+Biochimica et Biophysica Acta (BBA) - Gene Regulatory Mechanisms
+Biochimica et Biophysica Acta (BBA) - Gene Structure and Expression
+Biochimica et Biophysica Acta (BBA) - General Subjects
+Biochimica et Biophysica Acta (BBA) - Lipids and Lipid Metabolism
+Biochimica et Biophysica Acta (BBA) - Molecular Basis of Disease
+Biochimica et Biophysica Acta (BBA) - Molecular and Cell Biology of Lipids
+Biochimica et Biophysica Acta (BBA) - Molecular Cell Research
+Biochimica et Biophysica Acta (BBA) - Mucoproteins and Mucopolysaccharides
+Biochimica et Biophysica Acta (BBA) - Nucleic Acids and Protein Synthesis
+Biochimica et Biophysica Acta (BBA) - Protein Structure
+Biochimica et Biophysica Acta (BBA) - Protein Structure and Molecular Enzymology
+Biochimica et Biophysica Acta (BBA) - Proteins and Proteomics
+Biochimica et Biophysica Acta (BBA) - Reviews on Bioenergetics
+Biochimica et Biophysica Acta (BBA) - Reviews on Biomembranes
+Biochimica et Biophysica Acta (BBA) - Reviews on Cancer
+Biochimica et Biophysica Acta (BBA) - Specialized Section on Biophysical Subjects
+Biochimica et Biophysica Acta (BBA) - Specialized Section on Enzymological Subjects
+Biochimica et Biophysica Acta (BBA) - Specialized Section on Lipids and Related Subjects
+Biochimica et Biophysica Acta (BBA) - Specialized Section on Mucoproteins and Mucopolysaccharides
+Biochimica et Biophysica Acta (BBA) - Specialized Section on Nucleic Acids and Related Subjects
+Biochimie
+Biochimie Open
+Biocybernetics and Biomedical Engineering
+Bioelectrochemistry
+Bioelectrochemistry and Bioenergetics
+Bioinorganic Chemistry
+Biological Wastes
+Biologicals
+Biology of Blood and Marrow Transplantation
+Biology of the Cell
+Biomaterials
+Biomedical Journal
+BioMedicine
+Biomedicine & Aging Pathology
+Biomedicine & Pharmacotherapy
+Biomedicine & Preventive Nutrition
+Biomolecular Detection and Quantification
+Biomolecular Engineering
+Bioorganic Chemistry
+Bioorganic & Medicinal Chemistry
+Bioorganic & Medicinal Chemistry Letters
+Biophysical Chemistry
+Biophysical Journal
+Bioresource Technology
+Bioscience Hypotheses
+Biosensors and Bioelectronics
+BIOSILICO
+Biosystems
+Biotechnology Advances
+Biotechnology Reports
+Biotechnology Research and Innovation
+Blood Cells, Molecules, and Diseases
+Blood Reviews
+Boletín Médico del Hospital Infantil de México
+Boletín Médico Del Hospital Infantil de México (English Edition)
+Bone
+Bone and Mineral
+Bone Reports
+Brachytherapy
+Brain, Behavior, and Immunity
+The Brazilian Journal of Infectious Diseases
+Brazilian Journal of Microbiology
+The Breast
+Breast Diseases: A Year Book Quarterly
+Bulletin of the British Mycological Society
+Bulletin du Cancer
+Bulletin du Cancer/Radiothérapie
+Bulletin of Faculty of Pharmacy, Cairo University
+Bulletin de l'Institut Pasteur
+Cahiers de Nutrition et de Diététique
+Canadian Journal of Diabetes
+Cancer Cell
+Cancer Detection and Prevention
+Cancer Epidemiology
+Cancer Genetics
+Cancer Genetics and Cytogenetics
+Cancer Letters
+Cancer/Radiothérapie
+Cancer Treatment Communications
+Cancer Treatment and Research Communications
+Cancer Treatment Reviews
+Carbohydrate Polymers
+Carbohydrate Research
+Cardiovascular Radiation Medicine
+Cardiovascular Revascularization Medicine
+Cell
+Cell Biology International
+Cell Biology International Reports
+Cell Calcium
+Cell Chemical Biology
+Cell Differentiation
+Cell Differentiation and Development
+Cell Host & Microbe
+Cell Metabolism
+Cell Regeneration
+Cell Reports
+Cell Stem Cell
+The Cell Surface
+Cell Systems
+Cell Transplantation
+Cellular Immunology
+Cellular and Molecular Gastroenterology and Hepatology
+Cellular Signalling
+Cerevisia
+Chemico-Biological Interactions
+Chemistry & Biology
+Chemistry and Physics of Lipids
+Chinese Journal of Biotechnology
+Chinese Journal of Natural Medicines
+Clinica Chimica Acta
+Clínica e Investigación en Arteriosclerosis
+Clínica e Investigación en Ginecología y Obstetricia
+Clinical and Applied Immunology Reviews
+Clinical Biochemistry
+Clinical Breast Cancer
+Clinical Colorectal Cancer
+Clinical and Diagnostic Virology
+Clinical Epidemiology and Global Health
+Clinical Genitourinary Cancer
+Clinical Immunology
+Clinical Immunology and Immunopathology
+Clinical Immunology Newsletter
+Clinical Leukemia
+Clinical Lung Cancer
+Clinical Lymphoma
+Clinical Lymphoma and Myeloma
+Clinical Lymphoma Myeloma and Leukemia
+Clinical Mass Spectrometry
+Clinical Materials
+Clinical Microbiology and Infection
+Clinical Microbiology Newsletter
+Clinical Nutrition
+Clinical Nutrition ESPEN
+Clinical Nutrition Experimental
+Clinical Nutrition Supplements
+Clinical Oncology
+Clinical Ovarian Cancer
+Clinical Ovarian and Other Gynecologic Cancer
+Clinical Positron Imaging
+Clinical Prostate Cancer
+Clinical Radiology
+Clinical Radiology Extra
+Clinical Skin Cancer
+Clinical Therapeutics
+Clinical and Translational Radiation Oncology
+Clinical Trials and Regulatory Science in Cardiology
+Clinics in Endocrinology and Metabolism
+Collagen and Related Research
+Colloids and Surfaces B: Biointerfaces
+Combinatorial Chemistry - an Online Journal
+Comparative Biochemistry and Physiology
+Comparative Biochemistry and Physiology Part A: Molecular & Integrative Physiology
+Comparative Biochemistry and Physiology Part A: Physiology
+Comparative Biochemistry and Physiology Part B: Biochemistry and Molecular Biology
+Comparative Biochemistry and Physiology Part B: Comparative Biochemistry
+Comparative Biochemistry and Physiology Part C: Comparative Pharmacology
+Comparative Biochemistry and Physiology Part C: Pharmacology, Toxicology and Endocrinology
+Comparative Biochemistry and Physiology Part C: Toxicology & Pharmacology
+Comparative Biochemistry and Physiology Part D: Genomics and Proteomics
+Comparative and General Pharmacology
+Comparative Immunology, Microbiology and Infectious Diseases
+Comptes Rendus de l'Académie des Sciences - Series III - Sciences de la Vie
+Comptes Rendus Biologies
+Computational Biology and Chemistry
+Computational and Structural Biotechnology Journal
+Computational and Theoretical Polymer Science
+Computational Toxicology
+Contemporary Clinical Trials Communications
+Cor et Vasa
+Critical Reviews in Oncology/Hematology
+The Crop Journal
+Cryobiology
+Current Biology
+Current Opinion in Biotechnology
+Current Opinion in Cell Biology
+Current Opinion in Chemical Biology
+Current Opinion in Endocrine and Metabolic Research
+Current Opinion in Food Science
+Current Opinion in Genetics & Development
+Current Opinion in Immunology
+Current Opinion in Microbiology
+Current Opinion in Pharmacology
+Current Opinion in Physiology
+Current Opinion in Plant Biology
+Current Opinion in Structural Biology
+Current Opinion in Systems Biology
+Current Opinion in Toxicology
+Current Opinion in Virology
+Current Plant Biology
+Current Problems in Cancer
+Currents in Pharmacy Teaching and Learning
+Cytokine
+Cytokine & Growth Factor Reviews
+Cytotherapy
+Data in Brief
+Developmental Biology
+Developmental Cell
+Developmental & Comparative Immunology
+Diabetes & Metabolic Syndrome: Clinical Research & Reviews
+Diabetes & Metabolism
+Diabetes Research and Clinical Practice
+Diagnostic Microbiology and Infectious Disease
+Diagnóstico Prenatal
+Diagnostics in Neuropsychiatry
+Differentiation
+Digestive and Liver Disease
+DNA Repair
+Domestic Animal Endocrinology
+Douleurs : Évaluation - Diagnostic - Traitement
+Drug and Alcohol Dependence
+Drug Discovery Today
+Drug Discovery Today: BIOSILICO
+Drug Discovery Today: Disease Mechanisms
+Drug Discovery Today: Disease Models
+Drug Discovery Today: TARGETS
+Drug Discovery Today: Technologies
+Drug Discovery Today: Therapeutic Strategies
+Drug Invention Today
+Drug Metabolism and Pharmacokinetics
+Drug Resistance Updates
+EBioMedicine
+Ecological Genetics and Genomics
+Educación Química
+Egyptian Journal of Medical Human Genetics
+Electronic Journal of Biotechnology
+EMC - Endocrinologie
+EMC - Toxicologie-Pathologie
+Endocrinología, Diabetes y Nutrición
+Endocrinología, Diabetes y Nutrición (English ed.)
+Endocrinología y Nutrición
+Endocrinología y Nutrición (English Edition)
+Endocrinology and Metabolism Clinics of North America
+Enfermedades Infecciosas y Microbiología Clínica
+Enfermedades infecciosas y microbiologia clinica (English ed.)
+Environmental Toxicology and Pharmacology
+Enzyme and Microbial Technology
+Epidemics
+e-SPEN, the European e-Journal of Clinical Nutrition and Metabolism
+e-SPEN Journal
+EuPA Open Proteomics
+European Journal of Cancer
+European Journal of Cancer (1965)
+European Journal of Cancer and Clinical Oncology
+European Journal of Cancer Part B: Oral Oncology
+European Journal of Cancer Supplements
+European Journal of Cell Biology
+European Journal of Integrative Medicine
+European Journal of Medical Genetics
+European Journal of Medicinal Chemistry
+European Journal of Oncology Nursing
+European Journal of Pain
+European Journal of Pain Supplements
+European Journal of Pharmaceutical Sciences
+European Journal of Pharmaceutics and Biopharmaceutics
+European Journal of Pharmacology
+European Journal of Pharmacology: Environmental Toxicology and Pharmacology
+European Journal of Pharmacology: Molecular Pharmacology
+European Journal of Protistology
+European Journal of Surgical Oncology
+European Neuropsychopharmacology
+European Polymer Journal
+Evidence-based Oncology
+Experimental Cell Research
+Experimental Eye Research
+Experimental Gerontology
+Experimental Hematology
+Experimental and Molecular Pathology
+Experimental Mycology
+Experimental Parasitology
+Experimental Pathology
+Experimental and Toxicologic Pathology
+Experimentelle Pathologie
+Farmacéuticos de Atención Primaria
+Farmacia Hospitalaria
+Farmacia Hospitalaria (English Edition)
+Il Farmaco
+FEBS Letters
+FEBS Open Bio
+FEMS Immunology and Medical Microbiology
+FEMS Microbiology Ecology
+FEMS Microbiology Letters
+FEMS Microbiology Reviews
+FEMS Yeast Research
+Feuillets de Radiologie
+Fibrinolysis
+Fibrinolysis and Proteolysis
+Field Mycology
+Fish & Shellfish Immunology
+Fitoterapia
+Flora
+Flora oder Allgemeine Botanische Zeitung
+Flora oder Allgemeine botanische Zeitung. Abt. A, Physiologie und Biochemie
+Flora oder Allgemeine botanische Zeitung. Abt. B, Morphologie und Geobotanik
+Folding and Design
+Food and Bioproducts Processing
+Food Bioscience
+Food and Chemical Toxicology
+Food Chemistry
+Food and Cosmetics Toxicology
+Food Microbiology
+Food Science and Human Wellness
+Food and Waterborne Parasitology
+Forensic Science
+Forensic Science International
+Forensic Science International: Genetics
+Forensic Science International: Genetics Supplement Series
+Forensic Science International Supplement Series
+Free Radical Biology and Medicine
+Free Radicals and Antioxidants
+Frontiers in Laboratory Medicine
+Frontiers in Neuroendocrinology
+Fuel
+Fuel Processing Technology
+Fundamental and Applied Toxicology
+Fungal Biology
+Fungal Biology Reviews
+Fungal Ecology
+Fungal Genetics and Biology
+Future Journal of Pharmaceutical Sciences
+Gaceta Mexicana de Oncología
+Gene
+Gene Analysis Techniques
+Gene Expression Patterns
+Gene Reports
+General and Comparative Endocrinology
+General Pharmacology: The Vascular System
+Genes & Diseases
+Genetic Analysis: Biomolecular Engineering
+Genomic Medicine, Biomarkers, and Health Sciences
+Genomics
+Genomics Data
+Genomics, Proteomics & Bioinformatics
+Growth Hormone & IGF Research
+Gynecologic Oncology
+Gynecologic Oncology Case Reports
+Gynecologic Oncology Reports
+HardwareX
+HAYATI Journal of Biosciences
+Heliyon
+Hematology/Oncology and Stem Cell Therapy
+Hematology, Transfusion and Cell Therapy
+HIV & AIDS Review
+Hormones and Behavior
+HPB
+Human Immunology
+Human Microbiome Journal
+IDCases
+IJC Metabolic & Endocrine
+Imagerie de la Femme
+Immunity
+Immuno-analyse & Biologie Spécialisée
+Immunobiology
+Immunochemistry
+Immunology Letters
+Immunology Today
+ImmunoMethods
+Immunopharmacology
+Immunotechnology
+Indian Heart Journal
+Indian Journal of Medical Specialities
+Infectio
+Infection, Genetics and Evolution
+Inmunología
+Innovative Food Science & Emerging Technologies
+Inorganic Chemistry Communications
+Inorganic and Nuclear Chemistry Letters
+Inorganica Chimica Acta
+Insect Biochemistry
+Insect Biochemistry and Molecular Biology
+Insulin
+International Biodeterioration
+International Biodeterioration & Biodegradation
+International Congress Series
+International Immunopharmacology
+International Journal of Antimicrobial Agents
+International Journal of Biochemistry
+The International Journal of Biochemistry & Cell Biology
+International Journal of Biological Macromolecules
+International Journal of Cardiology
+International Journal of Chemical and Analytical Science
+International Journal of Developmental Neuroscience
+International Journal of Diabetes Mellitus
+International Journal of Drug Policy
+International Journal of Food Microbiology
+International Journal of Hygiene and Environmental Health
+International Journal of Immunopharmacology
+International Journal of Infectious Diseases
+International Journal of Mass Spectrometry
+International Journal of Mass Spectrometry and Ion Physics
+International Journal of Mass Spectrometry and Ion Processes
+International Journal of Medical Microbiology
+International Journal of Medical Microbiology Supplements
+International Journal of Mycobacteriology
+International Journal of Neuropharmacology
+International Journal of Nuclear Medicine and Biology
+International Journal of Paleopathology
+International Journal for Parasitology
+International Journal for Parasitology: Drugs and Drug Resistance
+International Journal for Parasitology: Parasites and Wildlife
+International Journal of Pharmaceutics
+International Journal of Radiation Applications and Instrumentation. Part B. Nuclear Medicine and Biology
+International Journal of Radiation Oncology*Biology*Physics
+International Journal of Surgery Open
+iScience
+Journal of the Academy of Nutrition and Dietetics
+Journal of Allergy and Clinical Immunology
+The Journal of Allergy and Clinical Immunology: In Practice
+Journal of the American Dietetic Association
+The Journal of the American Pharmaceutical Association (1912)
+Journal of the American Pharmaceutical Association (1961)
+Journal of the American Pharmaceutical Association (1996)
+Journal of the American Pharmaceutical Association (Practical Pharmacy ed.)
+Journal of the American Pharmaceutical Association (Scientific ed.)
+Journal of the American Pharmacists Association
+Journal of the American Society of Cytopathology
+Journal of the American Society of Hypertension
+Journal of the American Society for Mass Spectrometry
+Journal of Applied Biomedicine
+Journal of Autoimmunity
+Journal of Biochemical and Biophysical Methods
+Journal of Biological Standardization
+Journal of Bioscience and Bioengineering
+Journal of Biotechnology
+Journal of Bone Oncology
+Journal of Cancer Nursing
+Journal of Cancer Policy
+Journal of Cancer Research and Practice
+Journal of Cardiovascular Disease Research
+Journal of Cellular Immunotherapy
+Journal of Chemical Neuroanatomy
+Journal of Chromatography B
+Journal of Chromatography B: Biomedical Sciences and Applications
+Journal of Clinical Densitometry
+Journal of Clinical Forensic Medicine
+Journal of Clinical Lipidology
+Journal of Clinical and Translational Endocrinology: Case Reports
+Journal of Clinical & Translational Endocrinology
+Journal of Clinical Tuberculosis and Other Mycobacterial Diseases
+Journal of Clinical Virology
+Journal of Controlled Release
+Journal of Diabetes and its Complications
+Journal of Diabetic Complications
+Journal of Drug Delivery Science and Technology
+Journal of the Egyptian National Cancer Institute
+Journal of Ethnopharmacology
+Journal of the Faculty of Radiologists
+Journal of Fermentation Technology
+Journal of Fluorine Chemistry
+Journal of Food and Drug Analysis
+Journal of Forensic and Legal Medicine
+Journal of Free Radicals in Biology & Medicine
+Journal of Functional Foods
+Journal of Genetic Engineering and Biotechnology
+Journal of Genetics and Genomics
+Journal of Geriatric Oncology
+Journal of Global Antimicrobial Resistance
+Journal de Gynécologie Obstétrique et Biologie de la Reproduction
+Journal of Gynecology Obstetrics and Human Reproduction
+Journal of Herbal Medicine
+Journal of Hospital Infection
+Journal of Immunological Methods
+Journal of Infection
+Journal of Infection and Chemotherapy
+Journal of Inorganic Biochemistry
+Journal of Inorganic and Nuclear Chemistry
+Journal of Insect Physiology
+Journal of Lipid Mediators and Cell Signalling
+Journal of Magnetic Resonance
+Journal of Magnetic Resonance (1969)
+Journal of Microbiological Methods
+Journal of Microbiology, Immunology and Infection
+Journal of Molecular Biology
+Journal of Molecular Catalysis B: Enzymatic
+Journal of Molecular and Cellular Cardiology
+The Journal of Molecular Diagnostics
+Journal of Molecular Graphics and Modelling
+Journal of Molecular Structure
+Journal de Mycologie Médicale
+Journal of Neuroimmunology
+Journal of the Neurological Sciences
+Journal of Nutrition & Intermediary Metabolism
+The Journal of Nutritional Biochemistry
+Journal of Oncological Sciences
+Journal of Oral Biosciences
+Journal of Organometallic Chemistry
+Journal of Pain and Symptom Management
+Journal of Patient Safety & Infection Control
+Journal of Pediatric Oncology Nursing
+Journal of Pharmaceutical Analysis
+Journal of Pharmaceutical and Biomedical Analysis
+Journal of Pharmaceutical Sciences
+Journal of Pharmacological Methods
+Journal of Pharmacological Sciences
+Journal of Pharmacological and Toxicological Methods
+Journal of Pharmacy Research
+Journal of Photochemistry and Photobiology B: Biology
+Journal of Physiology-Paris
+Journal of Plant Physiology
+Journal of Proteomics
+Journal of Reproductive Immunology
+Journal of Sport and Health Science
+Journal of Steroid Biochemistry
+The Journal of Steroid Biochemistry and Molecular Biology
+Journal of Structural Biology
+Journal of Supramolecular Chemistry
+Journal of Thermal Biology
+Journal of Thoracic Oncology
+Journal of Trace Elements in Medicine and Biology
+Journal of Traditional Chinese Medical Sciences
+Journal of Ultrastructure and Molecular Structure Research
+Journal of Ultrastructure Research
+The Journal of Urology
+Journal of Virological Methods
+Journal of Young Pharmacists
+Krankenhaus-Hygiene + Infektionsverhütung
+The Lancet Diabetes & Endocrinology
+The Lancet Haematology
+The Lancet Infectious Diseases
+The Lancet Oncology
+Laser-Medizin: eine interdisziplinäre Zeitschrift  ; Praxis, Klinik, Forschung
+Legal Medicine
+Leukemia Research
+Leukemia Research Reports
+Life Sciences
+Life Sciences in Space Research
+Lung Cancer
+Magnetic Resonance Imaging
+Mammalian Biology
+Marine Genomics
+Matrix
+Matrix Biology
+Maturitas
+Mechanisms of Ageing and Development
+Mechanisms of Development
+Médecine & Longévité
+Médecine des Maladies Métaboliques
+Médecine Palliative
+Medical Dosimetry
+Medical Hypotheses
+Medical Laser Application
+Medical Mycology Case Reports
+Medical Photonics
+Medicina
+Medicina Paliativa
+Mendeleev Communications
+Meta Gene
+Metabolic Bone Disease and Related Research
+Metabolic Engineering
+Metabolic Engineering Communications
+Metabolism
+Methods
+MethodsX
+Microbes and Infection
+Microbial Pathogenesis
+Microbial Risk Analysis
+Microbiological Research
+Micron
+Microvascular Research
+Mitochondrion
+Molecular Aspects of Medicine
+Molecular and Biochemical Parasitology
+Molecular Cell
+Molecular Cell Biology Research Communications
+Molecular and Cellular Endocrinology
+Molecular and Cellular Neuroscience
+Molecular and Cellular Probes
+Molecular Diagnosis
+Molecular Genetics and Metabolism
+Molecular Genetics and Metabolism Reports
+Molecular Imaging & Biology
+Molecular Immunology
+Molecular Medicine Today
+Molecular Metabolism
+Molecular Oncology
+Molecular Phylogenetics and Evolution
+Molecular Therapy
+Molecular Therapy - Methods & Clinical Development
+Molecular Therapy - Nucleic Acids
+Molecular Therapy - Oncolytics
+Morphologie
+Multiple Sclerosis and Related Disorders
+Mutation Research/DNA Repair
+Mutation Research/DNA Repair Reports
+Mutation Research/DNAging
+Mutation Research/Environmental Mutagenesis and Related Subjects
+Mutation Research/Fundamental and Molecular Mechanisms of Mutagenesis
+Mutation Research/Genetic Toxicology
+Mutation Research/Genetic Toxicology and Environmental Mutagenesis
+Mutation Research Letters
+Mutation Research/Mutation Research Genomics
+Mutation Research/Reviews in Genetic Toxicology
+Mutation Research/Reviews in Mutation Research
+Mycological Research
+Mycologist
+Mycoscience
+Nano-Structures & Nano-Objects
+Nano Today
+NanoImpact
+Nanomedicine: Nanotechnology, Biology and Medicine
+Neoplasia
+Neurobiology of Aging
+Neurochemistry International
+Neuroepigenetics
+Neurologia i Neurochirurgia Polska
+Neuropeptides
+Neuropharmacology
+Neuroprotocols
+Neuropsychopharmacology
+NeuroRX
+Neurotherapeutics
+NeuroToxicology
+Neurotoxicology and Teratology
+New Biotechnology
+New Horizons in Clinical Case Reports
+New Microbes and New Infections
+New Negatives in Plant Science
+New Scientist
+NFS Journal
+Nitric Oxide
+Non-coding RNA Research
+Nuclear Medicine and Biology
+Nutrition
+Nutrition, Metabolism and Cardiovascular Diseases
+Nutrition Research
+Obesity Medicine
+Obesity Research & Clinical Practice
+Oceanologia
+Oncology Signaling
+One Health
+OpenNano
+Option/Bio
+Oral Oncology
+Oral Oncology Extra
+Oral Oncology Supplement
+Oral Science International
+Organic Geochemistry
+Osteoporosis and Sarcopenia
+Otolaryngologia Polska
+PAIN®
+Papillomavirus Research
+Parasite Epidemiology and Control
+Parasitology International
+Parasitology Today
+Parkinsonism & Related Disorders
+Pathogenesis
+Pathology
+Pathology and Oncology Research
+Pathology - Research and Practice
+Pediatria Polska
+Pediatric Hematology Oncology Journal
+Pedobiologia
+Peptides
+Personalized Medicine in Psychiatry
+Personalized Medicine Universe
+Perspectives in Medicine
+Perspectives in Science
+Perspectives in Vaccinology
+Pesticide Biochemistry and Physiology
+Pharmaceutica Acta Helvetiae
+Pharmaceutical Methods
+Pharmaceutical Science & Technology Today
+Le Pharmacien Hospitalier
+Le Pharmacien Hospitalier et Clinicien
+Pharmacognosy Journal
+Pharmacological Reports
+Pharmacological Research
+Pharmacological Research Communications
+Pharmacology Biochemistry and Behavior
+Pharmacology & Therapeutics
+Pharmacology & Therapeutics. Part A: Chemotherapy, Toxicology and Metabolic Inhibitors
+Pharmacology & Therapeutics. Part B: General and Systematic Pharmacology
+Pharmacology & Therapeutics. Part C: Clinical Pharmacology and Therapeutics
+PharmaNutrition
+Photodiagnosis and Photodynamic Therapy
+Physics and Imaging in Radiation Oncology
+Physics of Life Reviews
+Physics in Medicine
+Physiological and Molecular Plant Pathology
+Physiological Plant Pathology
+Physiology & Behavior
+Phytochemistry
+Phytochemistry Letters
+Phytomedicine
+Placenta
+Plant Gene
+Plant Physiology and Biochemistry
+Plant Science
+Plant Science Letters
+Plasmid
+Polish Annals of Medicine
+Polski Przegląd Otorynolaryngologiczny
+Polyhedron
+Polymer
+Polymer Contents
+Polymer Degradation and Stability
+Polymer Testing
+Postępy Psychiatrii i Neurologii
+Practical Laboratory Medicine
+Practical Radiation Oncology
+Primary Care Diabetes
+Procedia Food Science
+Procedia in Vaccinology
+Process Biochemistry
+Progress in Biophysics and Molecular Biology
+Progress in the Chemistry of Fats and other Lipids
+Progress in Growth Factor Research
+Progress in Histochemistry and Cytochemistry
+Progress in Lipid Research
+Progress in Neuro-Psychopharmacology
+Progress in Neuro-Psychopharmacology and Biological Psychiatry
+Progress in Polymer Science
+Prostaglandins
+Prostaglandins, Leukotrienes and Essential Fatty Acids
+Prostaglandins, Leukotrienes and Medicine
+Prostaglandins and Medicine
+Prostaglandins & Other Lipid Mediators
+Protein Expression and Purification
+Protist
+Psychoneuroendocrinology
+Pulmonary Pharmacology
+Pulmonary Pharmacology & Therapeutics
+Radiotherapy and Oncology
+REACH
+Reactive and Functional Polymers
+Reactive Polymers
+Reactive Polymers, Ion Exchangers, Sorbents
+Redox Biology
+Regenerative Therapy
+Regulatory Peptides
+Regulatory Toxicology and Pharmacology
+Reports of Practical Oncology
+Reports of Practical Oncology & Radiotherapy
+Reproductive Biology
+Reproductive Toxicology
+Research in Immunology
+Research in Microbiology
+Research in Social and Administrative Pharmacy
+Research in Virology
+Respiration Physiology
+Respiratory Investigation
+Respiratory Physiology & Neurobiology
+Results in Immunology
+Results in Pharma Sciences
+Reviews in Molecular Biotechnology
+Reviews in Vascular Medicine
+Revista Argentina de Endocrinología y Metabolismo
+Revista Argentina de Microbiología
+Revista Brasileira de Farmacognosia
+Revista Brasileira de Hematologia e Hemoterapia
+Revista Colombiana de Cancerología
+Revista Española de Enfermedades Metabólicas Óseas
+Revista Española de Geriatría y Gerontología
+Revista Española de Nutrición Comunitaria
+Revista Iberoamericana de Micología
+Revista del Laboratorio Clínico
+Revista Portuguesa de Endocrinologia, Diabetes e Metabolismo
+Revista de Senología y Patología Mamaria
+Revue Francophone de Cicatrisation
+La Revue de Médecine Interne
+La Revue de Médecine Légale
+Revue d'Oncologie Hématologie Pédiatrique
+Revue de Pneumologie Clinique
+Saudi Pharmaceutical Journal
+Science Bulletin
+Science & Justice
+Seminars in Breast Disease
+Seminars in Cancer Biology
+Seminars in Cell Biology
+Seminars in Cell & Developmental Biology
+Seminars in Developmental Biology
+Seminars in Hematology
+Seminars in Immunology
+Seminars in Oncology
+Seminars in Oncology Nursing
+Seminars in Radiation Oncology
+Seminars in Virology
+SoftwareX
+Soil Biology and Biochemistry
+Solar Energy Materials and Solar Cells
+Stem Cell Reports
+Stem Cell Research
+Steroids
+Structure
+Studies in Mycology
+Supportive Cancer Therapy
+Surgical Oncology
+Surgical Oncology Clinics of North America
+Surgical Pathology Clinics
+Synergy
+Synthetic and Systems Biotechnology
+Systematic and Applied Microbiology
+TARGETS
+Technical Innovations & Patient Support in Radiation Oncology
+Technical Tips Online
+Tetrahedron
+Tetrahedron: Asymmetry
+Tetrahedron Computer Methodology
+Tetrahedron Letters
+Thérapie
+Theriogenology
+Ticks and Tick-borne Diseases
+TIP
+Tissue and Cell
+Toxicological Sciences
+Toxicologie Analytique et Clinique
+Toxicology
+Toxicology and Applied Pharmacology
+Toxicology Letters
+Toxicology Reports
+Toxicology in Vitro
+Toxicon
+Trait - d'Union
+Transactions of the British Mycological Society
+Transactions of the Royal Society of Tropical Medicine and Hygiene
+Transfusion Clinique et Biologique
+Translational Medicine of Aging
+Translational Oncology
+Translational Proteomics
+Transplant Immunology
+Travel Medicine and Infectious Disease
+Trends in Biochemical Sciences
+Trends in Biotechnology
+Trends in Cancer
+Trends in Cell Biology
+Trends in Ecology & Evolution
+Trends in Endocrinology & Metabolism
+Trends in Food Science & Technology
+Trends in Genetics
+Trends in Immunology
+Trends in Microbiology
+Trends in Molecular Medicine
+Trends in Parasitology
+Trends in Pharmacological Sciences
+Trends in Plant Science
+Trials in Vaccinology
+Tubercle
+Tuberculosis
+Turkish Journal of Emergency Medicine
+Update on Cancer Therapeutics
+Urologic Oncology: Seminars and Original Investigations
+Urology
+Vaccine
+Vaccine Reports
+Vacunas
+Vascular Pharmacology
+Veterinary Immunology and Immunopathology
+Veterinary Microbiology
+Veterinary Parasitology
+Video Journal and Encyclopedia of GI Endoscopy
+Virology
+Virology Reports
+Virus Research
+World Science and Technology
+Wound Medicine
+Zeitschrift für Immunitaetsforschung, Experimentelle und Klinische Immunologie
+Zeitschrift für Immunitätsforschung: Immunobiology
+Zeitschrift für Medizinische Physik
+Zeitschrift für Pflanzenphysiologie
+Zentralblatt für Bakteriologie
+Zentralblatt für Bakteriologie. 1. Abt. Originale A, Medizinische Mikrobiologie, Infektionskrankheiten und Parasitologie
+Zentralblatt für Bakteriologie: I. Abt. Originale C: Allgemeine, angewandte und ökologische Mikrobiologie
+Zentralblatt für Bakteriologie, Mikrobiologie und Hygiene. 1. Abt. Originale. A, Medizinische Mikrobiologie, Infektionskrankheiten und Parasitologie
+Zentralblatt für Bakteriologie Mikrobiologie und Hygiene: I. Abt. Originale C: Allgemeine, angewandte und ökologische Mikrobiologie
+Zentralblatt für Bakteriologie, Mikrobiologie und Hygiene. Series A: Medical Microbiology, Infectious Diseases, Virology, Parasitology
+Zentralblatt für Bakteriologie, Parasitenkunde, Infektionskrankheiten und Hygiene. Zweite Naturwissenschaftliche Abteilung: Allgemeine, Landwirtschaftliche und Technische Mikrobiologie
+Zentralblatt für Bakteriologie, Parasitenkunde, Infektionskrankheiten und Hygiene. Zweite Naturwissenschaftliche Abteilung: Mikrobiologie der Landwirtschaft, der Technologie und des Umweltschutzes
+Zentralblatt für Hygiene und Umweltmedizin
+Zentralblatt für Mikrobiologie
+Zeszyty Naukowe WCO, Letters in Oncology Science
+Zoologischer Anzeiger
+Zoology

--- a/indra_db/schemas/principal_schema.py
+++ b/indra_db/schemas/principal_schema.py
@@ -301,7 +301,7 @@ class PrincipalSchema(Schema):
                                    'mesh_num'),
                         BtreeIndex('mesh_ref_annotations_qual_id_idx',
                                    'qual_num')]
-            id = Column(Integer, primary_key=True)
+            id = Column(BigInteger, primary_key=True)
             pmid_num = Column(Integer, nullable=False)
             mesh_num = Column(Integer, nullable=False)
             qual_num = Column(Integer)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ def main():
                                   'flask-compress', 'numpy'],
                       'cli': ['click', 'boto3'],
                       'copy': ['pgcopy'],
-                      'misc': ['matplotlib', 'numpy']}
+                      'misc': ['matplotlib', 'numpy'],
+                      'readonly': ['bs4']}
     extras_require['all'] = list({dep for deps in extras_require.values()
                                   for dep in deps})
     setup(name='indra_db',

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ def main():
                                   'flask-compress', 'numpy'],
                       'cli': ['click', 'boto3'],
                       'copy': ['pgcopy'],
-                      'misc': ['matplotlib', 'numpy'],
-                      'readonly': ['bs4']}
+                      'misc': ['matplotlib', 'numpy']}
     extras_require['all'] = list({dep for deps in extras_require.values()
                                   for dep in deps})
     setup(name='indra_db',
@@ -24,7 +23,7 @@ def main():
           packages=packages,
           include_package_data=True,
           install_requires=['sqlalchemy<1.4', 'psycopg2', 'cachetools',
-                            'termcolor'],
+                            'termcolor', 'bs4'],
           extras_require=extras_require,
           entry_points="""
           [console_scripts]


### PR DESCRIPTION
Places where fixed applied:
**pmc_oa**
Fixed the pmc_oa processor for updating the database.
The new update() logic: Find all pmcid's that are not in the database and then get the corresponding archive set. Pass the archive set to the upload_archives(). The old update logic confused "archives" and "articles" and the update logic was wrong.
**Docker files**
Some modifications were made to make the code robust and updated.
**indra_db schema**
id in table mesh_ref_annotations: int -> bignit
**Elsevier Manager**
Add method copy_into_db() 