### PR TITLE
Fix badge url

### DIFF
--- a/indra_db_service/call_handlers.py
+++ b/indra_db_service/call_handlers.py
@@ -374,7 +374,7 @@ class StatementApiCall(ApiCall):
                 ev_counts = res_json.pop('evidence_counts')
                 beliefs = res_json.pop('belief_scores')
                 stmts = stmts_from_json(stmts_json.values())
-                db_rest_url = BASE_URL or request.url_root[:-1] \
+                db_rest_url = (BASE_URL or request.url_root[:-1]) \
                     + self._env.globals['url_for']('root')[:-1]
                 html_assembler = \
                     HtmlAssembler(stmts, summary_metadata=res_json,

--- a/indra_db_service/call_handlers.py
+++ b/indra_db_service/call_handlers.py
@@ -24,7 +24,7 @@ from indra_db.client.principal.curation import *
 from indralab_auth_tools.log import note_in_log, is_log_running
 
 from indra_db_service.config import MAX_STMTS, REDACT_MESSAGE, TITLE, TESTING, \
-    jwt_nontest_optional, MAX_LIST_LEN
+    jwt_nontest_optional, MAX_LIST_LEN, BASE_URL
 from indra_db_service.errors import HttpUserError, ResultTypeError
 from indra_db_service.util import LogTracker, sec_since, get_source,\
     process_agent,  process_mesh_term, DbAPIError, iter_free_agents, \
@@ -374,7 +374,7 @@ class StatementApiCall(ApiCall):
                 ev_counts = res_json.pop('evidence_counts')
                 beliefs = res_json.pop('belief_scores')
                 stmts = stmts_from_json(stmts_json.values())
-                db_rest_url = request.url_root[:-1] \
+                db_rest_url = BASE_URL or request.url_root[:-1] \
                     + self._env.globals['url_for']('root')[:-1]
                 html_assembler = \
                     HtmlAssembler(stmts, summary_metadata=res_json,

--- a/indra_db_service/config.py
+++ b/indra_db_service/config.py
@@ -1,6 +1,7 @@
 __all__ = [
     "TITLE",
     "DEPLOYMENT",
+    "BASE_URL",
     "VUE_ROOT",
     "MAX_STMTS",
     "MAX_LIST_LEN",
@@ -16,6 +17,7 @@ from flask_jwt_extended import jwt_required
 
 TITLE = "The INDRA Database"
 DEPLOYMENT = environ.get("INDRA_DB_API_DEPLOYMENT")
+BASE_URL = environ.get("INDRA_DB_API_BASE_URL")
 CURATOR_SALT = environ.get("INDRA_DB_API_CURATOR_SALT")
 VUE_ROOT = environ.get("INDRA_DB_API_VUE_ROOT")
 if VUE_ROOT is not None and not VUE_ROOT.startswith("http"):

--- a/indra_db_service/gunicorn.conf.py
+++ b/indra_db_service/gunicorn.conf.py
@@ -13,8 +13,12 @@ def post_fork(server, worker):
     See: https://docs.gunicorn.org/en/stable/settings.html#post-fork
 
     This function is called after a worker is forked. It starts a thread to monitor
-    the database connection and reset it if it is lost.
+    the database connection and reset the connection if it is lost.
     """
-    thread = threading.Thread(target=monitor_database_connection, args=(60,), daemon=True)
+
+    # Setting check interval to 2x gunicorn timeout, which is 300 s.
+    thread = threading.Thread(
+        target=monitor_database_connection, args=(600,), daemon=True
+    )
     thread.start()
     print(f"Started database connection monitor thread in worker {worker.pid}.")


### PR DESCRIPTION
This PR fixes the badge link that previously had the server's localhost address instead of the db.indra.bio as base url. The fix includes creating a new `BASE_URL` environment variable, set with `INDRA_DB_API_BASE_URL`. This is then used to build the `db_rest_url` passed the to the `HtmlAssembler`.

Resolves #240.

Other changes:
- Up the user database connection check interval to 600 seconds