### PR TITLE
Complex fix

### DIFF
--- a/indra_db/client/readonly/query.py
+++ b/indra_db/client/readonly/query.py
@@ -19,6 +19,7 @@ from indra.sources.indra_db_rest.query_results import QueryResult, \
     StatementQueryResult, AgentQueryResult
 from indra.statements import get_statement_by_name, \
     get_all_descendants, make_statement_camel
+from indra_db.readonly_dumping.util import clean_json_loads
 
 from indra_db.schemas.readonly_schema import ro_role_map, ro_type_map, \
     SOURCE_GROUPS
@@ -588,7 +589,7 @@ class Query(object):
 
             # Add annotations if not present.
             if ev_limit != 0:
-                raw_json = json.loads(raw_json_bts.decode('utf-8'))
+                raw_json = clean_json_loads(raw_json_bts.decode('utf-8'))
                 ev_json = raw_json['evidence'][0]
                 if 'annotations' not in ev_json.keys():
                     ev_json['annotations'] = {}

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -1132,6 +1132,10 @@ def ensure_pa_meta():
     # Loop pa_meta dump and write load files for NameMeta, TextMeta, OtherMeta
     logger.info("Iterating over pa_meta dump")
     nones = (None, None, None, None)
+
+    def db_id_clean(s):
+        return s.replace('\n', ' ').replace('\r', ' ') if s else s
+
     with pa_meta_fpath.open('rt') as fh, \
             name_meta_tsv.open("wt") as name_fh, \
             text_meta_tsv.open("wt") as text_fh, \
@@ -1182,7 +1186,7 @@ def ensure_pa_meta():
             ]
             # db_name here if "other"
             row_end = [
-                db_id,
+                db_id_clean(db_id),
                 role_num,
                 type_num,
                 stmt_hash,
@@ -1202,7 +1206,7 @@ def ensure_pa_meta():
 
             if type_num == ro_type_map.get_int("Complex"):
                 dup1 = [
-                    db_id,
+                    db_id_clean(db_id),
                     -1,  # role_num
                     type_num, stmt_hash,
                     ev_count, belief_score,
@@ -1212,7 +1216,7 @@ def ensure_pa_meta():
                 ]
 
                 dup2 = [
-                    db_id,
+                    db_id_clean(db_id),
                     1,  # role_num
                     type_num, stmt_hash,
                     ev_count, belief_score,
@@ -1267,7 +1271,7 @@ def name_meta(local_ro_mngr: ReadonlyDatabaseManager):
                              name_meta_tsv.absolute().as_posix())
     create_primary_key(ro_mngr_local=local_ro_mngr,
                        table_name='name_meta',
-                       keys='ag_id')
+                       keys=['ag_id', 'mk_hash', 'role_num', 'ag_num'])
     # Build indices
     name_meta_table: ReadonlyTable = local_ro_mngr.tables["name_meta"]
     logger.info("Building indices for name_meta")
@@ -1306,7 +1310,7 @@ def text_meta(local_ro_mngr: ReadonlyDatabaseManager):
 
     create_primary_key(ro_mngr_local=local_ro_mngr,
                        table_name='text_meta',
-                       keys='ag_id')
+                       keys=['ag_id', 'mk_hash', 'role_num', 'ag_num'])
 
     # Build indices
     text_meta_table: ReadonlyTable = local_ro_mngr.tables["text_meta"]
@@ -1347,7 +1351,7 @@ def other_meta(local_ro_mngr: ReadonlyDatabaseManager):
 
     create_primary_key(ro_mngr_local=local_ro_mngr,
                        table_name='other_meta',
-                       keys='ag_id')
+                       keys=['ag_id', 'mk_hash', 'role_num', 'ag_num'])
     # Build indices
     other_meta_table: ReadonlyTable = local_ro_mngr.tables["other_meta"]
     logger.info("Building indices for other_meta")

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -1168,8 +1168,6 @@ def ensure_pa_meta():
 
             # Get role num
             role_num = ro_role_map.get_int(role)
-            is_complex_dup = True if type_num == ro_type_map.get_int(
-                "Complex") else False
 
             # NameMeta - db_name == "NAME"
             # TextMeta - db_name == "TEXT"
@@ -1193,7 +1191,7 @@ def ensure_pa_meta():
                 activity,
                 is_active,
                 agent_count,
-                is_complex_dup,
+                False,
             ]
             if db_name == "NAME":
                 name_writer.writerow(row_start + row_end)
@@ -1201,6 +1199,40 @@ def ensure_pa_meta():
                 text_writer.writerow(row_start + row_end)
             else:
                 other_writer.writerow(row_start + [db_name] + row_end)
+
+            if type_num == ro_type_map.get_int("Complex"):
+                dup1 = [
+                    db_id,
+                    -1,  # role_num
+                    type_num, stmt_hash,
+                    ev_count, belief_score,
+                    activity, is_active,
+                    agent_count,
+                    True  # is_complex_dup = True
+                ]
+
+                dup2 = [
+                    db_id,
+                    1,  # role_num
+                    type_num, stmt_hash,
+                    ev_count, belief_score,
+                    activity, is_active,
+                    agent_count,
+                    True
+                ]
+                if db_name == "NAME":
+                    name_writer.writerow(
+                        row_start[:1] + [0] + dup1)  # ag_num=0
+                    name_writer.writerow(
+                        row_start[:1] + [1] + dup2)  # ag_num=1
+                elif db_name == "TEXT":
+                    text_writer.writerow(row_start[:1] + [0] + dup1)
+                    text_writer.writerow(row_start[:1] + [1] + dup2)
+                else:
+                    other_writer.writerow(
+                        row_start[:1] + [0] + [db_name] + dup1)
+                    other_writer.writerow(
+                        row_start[:1] + [1] + [db_name] + dup2)
 
 
 # NameMeta, TextMeta, OtherMeta


### PR DESCRIPTION
This PR:

- Made duplicate entries for complex in tables: name meta, text_meta and other_meta with different role_num and agent_num. This allows the agent_interactions table to have the filtered non-duplicate complex. This logic follows the old readonly schema. 
- Used new combined primary key for the meta table since ag_id is not a unique column as we add duplicate entries for complex.
- Cleaned the db_id for replacing '/n' with a space. If there is a new line character, it will cause the spark to load a new line in the database.
- Use clean_json_loads when we fetch the statement from the database to avoid json misformat