### PR TITLE
Readonly pipeline fix

### DIFF
--- a/indra_db/readonly_dumping/export_assembly_refinement.py
+++ b/indra_db/readonly_dumping/export_assembly_refinement.py
@@ -110,11 +110,13 @@ if __name__ == '__main__':
             s3_path.upload(s3, body=local_file.read_bytes())
             logger.info(f"Uploaded {local_file} → {s3_path}")
 
-        if refinements_fpath.exists() or refinement_cycles_fpath.exists():
-            for local_file in [refinements_fpath, refinement_cycles_fpath]:
-                s3_path = base_s3_path.get_element_path(local_file.name)
-                s3_path.upload(s3, body=local_file.read_bytes())
-                logger.info(f"Uploaded {local_file} → {s3_path}")
+        for file in [refinements_fpath, refinement_cycles_fpath]:
+            if file.exists():
+                s3_path = base_s3_path.get_element_path(file.name)
+                s3_path.upload(s3, body=file.read_bytes())
+                logger.info(f"Uploaded {file} → {s3_path}")
+            else:
+                logger.warning(f"Skipped upload: {file} does not exist")
 
         end_time = time.time()
         record_time(export_benchmark.absolute().as_posix(),

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -757,7 +757,7 @@ def fast_raw_pa_link_helper(local_ro_mngr):
     # Execute query to get db_indo_id tp source_api mapping
     with db.engine.connect() as conn:
         result = conn.execute("SELECT id, source_api FROM db_info")
-        id_to_source_api = {row["id"]: row["source_api"] for row in result}
+        id_to_source_api = {row["id"]: row["db_name"] for row in result}
 
     raw_stmt_id_source_map = {
         int(raw_stmt_id): src for raw_stmt_id, src in query.all()

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -838,6 +838,7 @@ def fast_raw_pa_link_helper(local_ro_mngr):
                     df['reading_id'] = pd.to_numeric(df['reading_id'], errors='coerce').astype('Int64')
                     df['db_info_id'] = pd.to_numeric(df['db_info_id'], errors='coerce').astype('Int32')
                     df['type_num'] = pd.to_numeric(df['type_num'], errors='coerce').astype('Int16')
+                    df['raw_stmt_src_name'] = df['raw_stmt_src_name'].astype('string')
                     df.to_parquet(temp_parquet_file, index=False)
                     rows.clear()  # Clear rows after saving
                     chunk_num += 1  # Increment chunk number

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -854,6 +854,7 @@ def fast_raw_pa_link_helper(local_ro_mngr):
                 df['reading_id'] = pd.to_numeric(df['reading_id'], errors='coerce').astype('Int64')
                 df['db_info_id'] = pd.to_numeric(df['db_info_id'], errors='coerce').astype('Int32')
                 df['type_num'] = pd.to_numeric(df['type_num'], errors='coerce').astype('Int16')
+                df['raw_stmt_src_name'] = df['raw_stmt_src_name'].astype('string')
                 df.to_parquet(temp_parquet_file, index=False)
                 rows.clear()  # Clear remaining rows
 

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -777,7 +777,7 @@ def fast_raw_pa_link_helper(local_ro_mngr):
             info = {"raw_json": stmt_json_raw}
             if db_info_id and db_info_id != "\\N":
                 info["db_info_id"] = int(db_info_id)
-                info["src"] = id_to_source_api[db_info_id]
+                info["src"] = id_to_source_api[int(db_info_id)]
             if reading_id and reading_id != "\\N":
                 info["reading_id"] = int(reading_id)
             raw_id_to_info[int(raw_stmt_id)] = info

--- a/indra_db/readonly_dumping/readonly_dumping.py
+++ b/indra_db/readonly_dumping/readonly_dumping.py
@@ -755,9 +755,8 @@ def fast_raw_pa_link_helper(local_ro_mngr):
     db = get_db("primary")
 
     # Execute query to get db_indo_id tp source_api mapping
-    with db.engine.connect() as conn:
-        result = conn.execute("SELECT id, source_api FROM db_info")
-        id_to_source_api = {row["id"]: row["db_name"] for row in result}
+    rows = db.select_all(db.DBInfo)
+    id_to_source_api = {r.id: r.db_name for r in rows}
 
     raw_stmt_id_source_map = {
         int(raw_stmt_id): src for raw_stmt_id, src in query.all()


### PR DESCRIPTION
This PR fixed the following issue when running some updated code on a large scale.

- Handle the file case when there are no refinement cycle files. 
- Use db_name as the source name
- Enforce the data type for src in fast_raw_pa_link table